### PR TITLE
Add blank line for proper bullet list rendering

### DIFF
--- a/docs/wiki/History.md
+++ b/docs/wiki/History.md
@@ -15,6 +15,7 @@ It is our hope that MSYS2 be viewed as a complementary off-shot of Cygwin (even 
 ## MinGW-w64
 
 MinGW is an abbreviation of *Minimalist GNU for Windows*. The idea of MinGW is to provide a development platform for building cross-platform applications on Windows. The important pieces are:
+
 * a set of FOSS Windows specific header files and import libraries which enable the use of the Windows API,
 * a supplementary library and a runtime that fill in some gaps.
 


### PR DESCRIPTION
Currently, what's meant to be the first bullet list on https://www.msys2.org/wiki/History/ (beginning right after "The important pieces are:") is not properly rendered. Adding a blank line before the first bulleted point should fix that.